### PR TITLE
fix: broken chat links on landing page

### DIFF
--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -9,7 +9,7 @@ import AltaMLLogo from '@/altaml_landing.png';
 // Amplify imports for chat session creation
 import type { Schema } from '@/../amplify/data/resource';
 import { amplifyClient } from '@/utils/amplify-utils';
-import { defaultAgents } from '@/utils/config';
+import { defaultAgents, BedrockAgent } from '@/utils/config';
 
 // Components
 import AgentCard from '@/components/AgentCard';
@@ -49,7 +49,9 @@ export default function Landing() {
       const chatSession: Schema['ChatSession']['createType'] = {
         aiBotInfo: {
           aiBotName: agentInfo.name,
-          aiBotId: agentId,
+          aiBotId: agentInfo.source === 'bedrockAgent' 
+            ? (agentInfo as BedrockAgent).agentId 
+            : agentId, // Use actual AWS agent ID for Bedrock agents, config key for others
           aiBotAliasId: 'agentAliasId' in agentInfo ? agentInfo.agentAliasId : undefined,
           aiBotVersion: undefined
         }


### PR DESCRIPTION
On the landing page, when you clicked on any of the non-Production agent buttons, then when you tried to chat, it didn't work. This is because the other agents (Maintenance, Regulatory, Petrophysics) are bedrock agents and they require the AWS agent ID to create a new chat session. Production agent still worked as it is not a bedrock agent.